### PR TITLE
Fixed ESLint and Prettier errors

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 import { useEffect, useState, useRef } from "react";
-import { redirect } from "next/navigation";
 import { Loader } from "@/components/ui/loader";
 import Logo from "./components/Logo";
 import { signIn } from "next-auth/react";
@@ -131,7 +130,7 @@ export default function App({ isAuthenticated, products }: { isAuthenticated: bo
       {status !== "initial" ? <Loader isDoneLoading={status === "finished"} /> : null}
       <form
         onSubmit={handleSubmit}
-        className="font-['Helvetica Neue',Helvetica,Arial,sans-serif] absolute top-1/2 left-1/2 z-10 w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 px-4 text-3xl sm:text-4xl md:text-5xl lg:text-6xl leading-2 font-bold text-black sm:w-[calc(100%-4rem)] md:max-w-[61%] dark:text-white"
+        className="font-['Helvetica Neue',Helvetica,Arial,sans-serif] absolute top-1/2 left-1/2 z-10 w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 px-4 text-3xl leading-2 font-bold text-black sm:w-[calc(100%-4rem)] sm:text-4xl md:max-w-[61%] md:text-5xl lg:text-6xl dark:text-white"
         style={{ lineHeight: "150%" }}
       >
         I want to make
@@ -139,7 +138,7 @@ export default function App({ isAuthenticated, products }: { isAuthenticated: bo
           ref={inputRef}
           name="about"
           placeholder="..."
-          className="mt-2 block w-full resize-none rounded-[20px] border-4 border-black px-4 py-4 text-3xl sm:text-4xl md:text-5xl lg:text-6xl sm:px-6 sm:py-6 dark:border-white dark:text-black"
+          className="mt-2 block w-full resize-none rounded-[20px] border-4 border-black px-4 py-4 text-3xl sm:px-6 sm:py-6 sm:text-4xl md:text-5xl lg:text-6xl dark:border-white dark:text-black"
           value={about}
           style={{
             backgroundColor: "rgba(255, 144, 232)",
@@ -165,7 +164,7 @@ export default function App({ isAuthenticated, products }: { isAuthenticated: bo
                         setSelectedProduct(e.target.value);
                       }
                     }}
-                    className="mt-4 block w-full appearance-none rounded-[20px] border-4 border-black px-4 py-4 text-3xl sm:text-4xl md:text-5xl lg:text-6xl sm:px-6 sm:py-6 dark:border-white dark:text-black"
+                    className="mt-4 block w-full appearance-none rounded-[20px] border-4 border-black px-4 py-4 text-3xl sm:px-6 sm:py-6 sm:text-4xl md:text-5xl lg:text-6xl dark:border-white dark:text-black"
                     style={{
                       backgroundColor: "rgba(255, 201, 0)",
                     }}
@@ -203,7 +202,7 @@ export default function App({ isAuthenticated, products }: { isAuthenticated: bo
         <Button
           type="submit"
           variant="outline"
-          className="mt-8 w-full cursor-pointer rounded-full border-4 border-black bg-black p-4 text-2xl sm:text-3xl md:text-4xl lg:text-5xl sm:p-6 md:p-8 font-bold text-white transition-colors hover:bg-white hover:text-black dark:border-white dark:bg-black dark:text-white dark:hover:bg-white dark:hover:text-black"
+          className="mt-8 w-full cursor-pointer rounded-full border-4 border-black bg-black p-4 text-2xl font-bold text-white transition-colors hover:bg-white hover:text-black sm:p-6 sm:text-3xl md:p-8 md:text-4xl lg:text-5xl dark:border-white dark:bg-black dark:text-white dark:hover:bg-white dark:hover:text-black"
           disabled={status !== "initial"}
         >
           {status === "generating" ? "Creating..." : "Create"}
@@ -220,7 +219,7 @@ export default function App({ isAuthenticated, products }: { isAuthenticated: bo
           <div className="absolute inset-0 bg-[rgba(255,144,232,0.8)] backdrop-blur-sm" />
           <Button
             onClick={() => signIn("gumroad")}
-            className="relative z-10 cursor-pointer rounded-full border-4 border-black bg-white p-4 text-2xl sm:text-3xl md:text-4xl lg:text-5xl sm:p-6 md:p-8 font-bold text-black transition-colors hover:bg-black hover:text-white dark:border-white"
+            className="relative z-10 cursor-pointer rounded-full border-4 border-black bg-white p-4 text-2xl font-bold text-black transition-colors hover:bg-black hover:text-white sm:p-6 sm:text-3xl md:p-8 md:text-4xl lg:text-5xl dark:border-white"
           >
             Login with Gumroad
           </Button>

--- a/app/gum/[id]/Editor.tsx
+++ b/app/gum/[id]/Editor.tsx
@@ -290,6 +290,7 @@ export default function Editor({ initialHtml, gumId }: { initialHtml: string; gu
 
   return (
     <>
+      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
       <script src="https://cdn.tailwindcss.com"></script>
       <div className="min-h-screen bg-[#f4f4f0] dark:bg-black dark:text-white">
         <div ref={resultsRef} className="relative min-h-screen w-full p-4">

--- a/app/gum/[id]/Viewer.tsx
+++ b/app/gum/[id]/Viewer.tsx
@@ -3,6 +3,7 @@
 export default function Viewer({ html }: { html: string }) {
   return (
     <>
+      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
       <script src="https://cdn.tailwindcss.com"></script>
       <div dangerouslySetInnerHTML={{ __html: html }} className="min-h-screen w-full" />
     </>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import eslintPluginPrettier from "eslint-plugin-prettier";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,8 +13,12 @@ const compat = new FlatCompat({
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript", "prettier"),
   {
+    plugins: {
+      prettier: eslintPluginPrettier,
+    },
     rules: {
       "prettier/prettier": "error",
+      "@typescript-eslint/no-explicit-any": "off",
     },
   },
 ];


### PR DESCRIPTION
The Tailwind classes in some files were automatically changed with [Automatic Class sorting](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier). This is on by default through the `prettier-plugin-tailwindcss` package (which was already installed) but it wasn't doing this earlier since Prettier was partially broken.

The changes to the ESlint config fix issues with Linting.

The no-sync-script lines are necessary for `next build` to work