### PR TITLE
Command bar restyling

### DIFF
--- a/app/gum/[id]/Editor.tsx
+++ b/app/gum/[id]/Editor.tsx
@@ -274,7 +274,7 @@ export default function Editor({ initialHtml, gumId }: { initialHtml: string; gu
           </style>
         </head>
         <body>
-          <textarea rows="1" class="${editState === "idle" ? "idle" : ""}" placeholder="/ to make changes"></textarea>
+          <textarea rows="1" class="${editState === "idle" ? "idle" : ""}" placeholder="Type / to make changes"></textarea>
         </body>
       </html>
     `);


### PR DESCRIPTION
- Made input auto-resize based on prompt length
- Switched prompt shortcut to use `/` instead of cmd+k
- Restyled command bar

<img width="613" alt="image" src="https://github.com/user-attachments/assets/6bbda0d0-5ea6-47ed-a3da-688a7ca8464d" />

<img width="611" alt="image" src="https://github.com/user-attachments/assets/29a98aa7-a84f-4aff-a7c6-b550674973ca" />
